### PR TITLE
fix numpy > 1.2 bug

### DIFF
--- a/cdspyreadme/core_test.py
+++ b/cdspyreadme/core_test.py
@@ -66,7 +66,7 @@ class ReadMeCase(unittest.TestCase):
         """test numpy table"""
         tablemaker = CDSTablesMaker()
         ntab = np.array([(1.1, 1, 'test'), (2.2, 2, 'test2'), (3.3, 3, None), (None, -1, '')],
-                        dtype=[('mag', np.float), ('recno', np.int32), ('comment', np.str_, 10)])
+                        dtype=[('mag', np.float64), ('recno', np.int32), ('comment', np.str_, 10)])
         tablename = ReadMeCase.__result_file("numpy")
         tablemaker.addTable(ntab,
                             name=tablename,


### PR DESCRIPTION
Hi Gilles, 

There was a tiny bug with the numpy type `np.float` being deprecated when running the tests:

```
❯ python -m unittest cdspyreadme/core_test.py 
change current dir to tests
generate tests/out_table_astropy tests/ReadMe_astropy
.%elapse time test_file = 0.0032868385314941406
%elapse time test_file add_table = 0.015805959701538086
%elapse time test_file write = 0.22094321250915527
generate tests/out_table_file1 tests/out_table_file2 tests/ReadMe_file
. ee    b     col3  col4 
deg                     
---- ------ ----- ------
   1    4.0   1.1 -1.001
   2 1115.0   2.0    2.0
None    nan 999.0    0.0
   4   None  12.3 -99.12
 999    999  12.3    nan
.generate tests/out_table_mrt tests/ReadMe_mrt
.E
======================================================================
ERROR: test_numpy (cdspyreadme.core_test.ReadMeCase.test_numpy)
test numpy table
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/manon.marchand/Documents/my-personal-github/cds.pyreadme/cdspyreadme/core_test.py", line 69, in test_numpy
    dtype=[('mag', np.float), ('recno', np.int32), ('comment', np.str_, 10)])
                   ^^^^^^^^
  File "/home/manon.marchand/.conda/envs/pyreadme/lib/python3.11/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

----------------------------------------------------------------------
Ran 5 tests in 0.282s

FAILED (errors=1)
```

It is replaced by `np.float64` now :slightly_smiling_face: 